### PR TITLE
fix(package): add @dcos namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tslint-config",
+  "name": "@dcos/tslint-config",
   "version": "0.0.1",
   "description": "Shared tslint config for DCOS projects using typescript",
   "main": "index.js",


### PR DESCRIPTION
Wouldn't we want scoping the package under `@dcos` org?