### PR TITLE
chore: upgrade peer dependecy tslint-prettier-config

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/dcos-labs/tslint-config#readme",
   "peerDependencies": {
     "tslint": "5.9.1",
-    "tslint-config-prettier": "1.10.0",
+    "tslint-config-prettier": "1.11.0",
     "tslint-eslint-rules": "5.1.0",
     "tslint-plugin-prettier": "1.3.0",
     "tslint-react": "3.5.1"


### PR DESCRIPTION
tslint-prettier-config 1.11.0 was released today we should put this as our new peer dependency.