### PR TITLE
chore: remove no-unused-variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,13 +52,6 @@ module.exports = {
       true,
       "ignore-blank-lines"
     ],
-    "no-unused-variable": [
-      true,
-      "check-parameters",
-      {
-        "ignore-pattern": "^_"
-      }
-    ],
     "no-use-before-declare": false,
     "quotemark": [
       false


### PR DESCRIPTION
because tslint tells us that this check is deprecated in favor of the
builtin of typescript's compiler.

here's a CI-run with that message: https://jenkins.mesosphere.com/service/jenkins/blue/organizations/jenkins/frontend%2Fdcos-ui-oss-pipeline/detail/PR-3751/8/pipeline